### PR TITLE
Feature: Integrate Distance Parameters into Distance classes

### DIFF
--- a/include/gwmodelpp/CGwmGWDR.h
+++ b/include/gwmodelpp/CGwmGWDR.h
@@ -228,7 +228,6 @@ private:
 
 private:
     vector<CGwmSpatialWeight> mSpatialWeights;
-    vector<DistanceParameter*> mDistParameters;
 
     vec mY;
     mat mX;

--- a/include/gwmodelpp/CGwmGWRBasic.h
+++ b/include/gwmodelpp/CGwmGWRBasic.h
@@ -118,8 +118,6 @@ protected:
     bool mHasFTest = false;
     bool mHasPredict = false;
     
-    DistanceParameter* mPredictionDistanceParameter = nullptr;
-
     bool mIsAutoselectIndepVars = false;
     double mIndepVarSelectionThreshold = 3.0;
     IndepVarsSelectCriterionCalculator mIndepVarsSelectionCriterionFunction = &CGwmGWRBasic::indepVarsSelectionCriterionSerial;

--- a/include/gwmodelpp/CGwmSpatialMonoscaleAlgorithm.h
+++ b/include/gwmodelpp/CGwmSpatialMonoscaleAlgorithm.h
@@ -62,9 +62,7 @@ public:
     void createDistanceParameter();
 
 protected:
-    CGwmSpatialWeight mSpatialWeight;   //!< Spatial weight configuration.
-    
-    DistanceParameter* mDistanceParameter = nullptr;    //!< Distance parameter used in calling for CGwmSpatialWeight::weightVector() and CGwmMinkwoskiDistance::distance().
+    CGwmSpatialWeight mSpatialWeight;   //!< Spatial weight configuration.    
 };
 
 #endif  // CGWMSPATIALMONOSCALEALGORITHM_H

--- a/include/gwmodelpp/spatialweight/CGwmCRSDistance.h
+++ b/include/gwmodelpp/spatialweight/CGwmCRSDistance.h
@@ -4,33 +4,35 @@
 #include "CGwmDistance.h"
 
 /**
- * @brief Struct of parameters used in spatial distance calculating according to coordinate reference system. 
- * Usually a pointer to object of this class is passed to CGwmCRSDistance::distance().
- */
-struct CRSDistanceParameter : public DistanceParameter
-{
-    mat focusPoints;    //!< Matrix of focus points' coordinates. The shape of it must be nx2 and the first column is longitudes or x-coordinate, the second column is latitudes or y-coordinate.
-    mat dataPoints;     //!< Matrix of data points' coordinates. The shape of it must be nx2 and the first column is longitudes or x-coordinate, the second column is latitudes or y-coordinate.
-
-    /**
-     * @brief Construct a new CRSDistanceParameter object.
-     * 
-     * @param fp Reference to focus points.
-     * @param dp Reference to data points.
-     */
-    CRSDistanceParameter(const mat& fp, const mat& dp) : DistanceParameter()
-        , focusPoints(fp)
-        , dataPoints(dp)
-    {
-        total = fp.n_rows;
-    }
-};
-
-/**
  * @brief Class for calculating spatial distance according to coordinate reference system.
  */
 class CGwmCRSDistance : public CGwmDistance
 {
+public:
+
+    /**
+     * @brief Struct of parameters used in spatial distance calculating according to coordinate reference system. 
+     * Usually a pointer to object of this class is passed to CGwmCRSDistance::distance().
+     */
+    struct Parameter : public CGwmDistance::Parameter
+    {
+        mat focusPoints;    //!< Matrix of focus points' coordinates. The shape of it must be nx2 and the first column is longitudes or x-coordinate, the second column is latitudes or y-coordinate.
+        mat dataPoints;     //!< Matrix of data points' coordinates. The shape of it must be nx2 and the first column is longitudes or x-coordinate, the second column is latitudes or y-coordinate.
+
+        /**
+         * @brief Construct a new CRSDistanceParameter object.
+         * 
+         * @param fp Reference to focus points.
+         * @param dp Reference to data points.
+         */
+        Parameter(const mat& fp, const mat& dp) : CGwmDistance::Parameter()
+            , focusPoints(fp)
+            , dataPoints(dp)
+        {
+            total = fp.n_rows;
+        }
+    };
+
 public:
 
     /**
@@ -128,9 +130,9 @@ public:
      * 
      * @return DistanceParameter* The pointer to parameters.
      */
-    virtual DistanceParameter* makeParameter(initializer_list<DistParamVariant> plist) override;
+    virtual CGwmDistance::Parameter* makeParameter(initializer_list<DistParamVariant> plist) override;
 
-    virtual vec distance(DistanceParameter* parameter, uword focus) override;
+    virtual vec distance(uword focus) override;
 
 protected:
     bool mGeographic = false;

--- a/include/gwmodelpp/spatialweight/CGwmCRSDistance.h
+++ b/include/gwmodelpp/spatialweight/CGwmCRSDistance.h
@@ -83,7 +83,7 @@ public:
     explicit CGwmCRSDistance(bool isGeographic);
 
     /**
-     * @brief Construct a new CGwmCRSDistance object.
+     * @brief Copy construct a new CGwmCRSDistance object.
      * 
      * @param distance Refernce to object for copying.
      */

--- a/include/gwmodelpp/spatialweight/CGwmCRSDistance.h
+++ b/include/gwmodelpp/spatialweight/CGwmCRSDistance.h
@@ -130,12 +130,15 @@ public:
      * 
      * @return DistanceParameter* The pointer to parameters.
      */
-    virtual CGwmDistance::Parameter* makeParameter(initializer_list<DistParamVariant> plist) override;
+    virtual void makeParameter(initializer_list<DistParamVariant> plist) override;
 
     virtual vec distance(uword focus) override;
+    virtual double maxDistance() override;
+    virtual double minDistance() override;
 
 protected:
     bool mGeographic = false;
+    unique_ptr<Parameter> mParameter = nullptr;
 
 private:
     CalculatorType mCalculator = &EuclideanDistance;

--- a/include/gwmodelpp/spatialweight/CGwmDMatDistance.h
+++ b/include/gwmodelpp/spatialweight/CGwmDMatDistance.h
@@ -49,12 +49,15 @@ public:
      * 
      * @return DistanceParameter* The pointer to parameters.
      */
-    virtual CGwmDistance::Parameter* makeParameter(initializer_list<DistParamVariant> plist) override;
+    virtual void makeParameter(initializer_list<DistParamVariant> plist) override;
     
     virtual vec distance(uword focus) override;
+    virtual double maxDistance() override;
+    virtual double minDistance() override;
 
 private:
     string mDMatFile;
+    unique_ptr<Parameter> mParameter = nullptr;
 };
 
 inline string CGwmDMatDistance::dMatFile() const

--- a/include/gwmodelpp/spatialweight/CGwmDMatDistance.h
+++ b/include/gwmodelpp/spatialweight/CGwmDMatDistance.h
@@ -6,21 +6,23 @@
 
 using namespace std;
 
-struct DMatDistanceParameter : public DistanceParameter
-{
-    uword rowSize;
-
-    DMatDistanceParameter(uword size, uword rows) : rowSize(size) 
-    {
-        total = rows;
-    }
-};
-
 /**
  * [NOT AVALIABLE]
  */
 class CGwmDMatDistance : public CGwmDistance
 {
+public:
+
+    struct Parameter : public CGwmDistance::Parameter
+    {
+        uword rowSize;
+
+        Parameter(uword size, uword rows) : rowSize(size) 
+        {
+            total = rows;
+        }
+    };
+
 public:
     explicit CGwmDMatDistance(string dmatFile);
     CGwmDMatDistance(const CGwmDMatDistance& distance);
@@ -47,9 +49,9 @@ public:
      * 
      * @return DistanceParameter* The pointer to parameters.
      */
-    virtual DistanceParameter* makeParameter(initializer_list<DistParamVariant> plist) override;
+    virtual CGwmDistance::Parameter* makeParameter(initializer_list<DistParamVariant> plist) override;
     
-    virtual vec distance(DistanceParameter* parameter, uword focus) override;
+    virtual vec distance(uword focus) override;
 
 private:
     string mDMatFile;

--- a/include/gwmodelpp/spatialweight/CGwmDistance.h
+++ b/include/gwmodelpp/spatialweight/CGwmDistance.h
@@ -65,18 +65,6 @@ public:
 public:
 
     /**
-     * @brief Construct a new CGwmDistance object.
-     */
-    explicit CGwmDistance() {};
-
-    /**
-     * @brief Construct a new CGwmDistance object.
-     * 
-     * @param d Reference to object for copying.
-     */
-    CGwmDistance(const CGwmDistance& d) {};
-
-    /**
      * @brief Destroy the CGwmDistance object.
      */
     virtual ~CGwmDistance() {};

--- a/include/gwmodelpp/spatialweight/CGwmDistance.h
+++ b/include/gwmodelpp/spatialweight/CGwmDistance.h
@@ -9,20 +9,6 @@
 using namespace std;
 using namespace arma;
 
-/**
- * @brief Struct of parameters used in spatial distance calculating. 
- * Usually a pointer to object of its derived classes is passed to CGwmDistance::distance().
- */
-struct DistanceParameter
-{
-    uword total;    //!< Total focus points.
-
-    /**
-     * @brief Construct a new DistanceParameter object.
-     */
-    DistanceParameter(): total(0) {}
-};
-
 typedef variant<mat, vec, uword> DistParamVariant;
 
 /**
@@ -43,6 +29,20 @@ typedef variant<mat, vec, uword> DistParamVariant;
 class CGwmDistance
 {
 public:
+
+    /**
+     * @brief Struct of parameters used in spatial distance calculating. 
+     * Usually a pointer to object of its derived classes is passed to CGwmDistance::distance().
+     */
+    struct Parameter
+    {
+        uword total;    //!< Total focus points.
+
+        /**
+         * @brief Construct a new DistanceParameter object.
+         */
+        Parameter(): total(0) {}
+    };
 
     /**
      * @brief Enum for types of distance.
@@ -94,6 +94,11 @@ public:
      */
     virtual DistanceType type() = 0;
 
+    virtual Parameter* parameter() const
+    {
+        return mParameter;
+    }
+
 
 public:
 
@@ -104,7 +109,7 @@ public:
      * @param plist A list of parameters. 
      * @return DistanceParameter* The pointer to parameters.
      */
-    virtual DistanceParameter* makeParameter(initializer_list<DistParamVariant> plist) = 0;
+    virtual Parameter* makeParameter(initializer_list<DistParamVariant> plist) = 0;
 
     /**
      * @brief Calculate distance vector for a focus point. 
@@ -113,7 +118,7 @@ public:
      * @param focus Focused point's index. Require focus < total.
      * @return Distance vector for the focused point.
      */
-    virtual vec distance(DistanceParameter* parameter, uword focus) = 0;
+    virtual vec distance(uword focus) = 0;
 
     /**
      * @brief Get maximum distance among all points。
@@ -122,7 +127,7 @@ public:
      * @param parameter Pointer to parameter object used for calculating distance. 
      * @return Maximum distance. 
      */
-    double maxDistance(uword total, DistanceParameter* parameter);
+    double maxDistance();
     
     /**
      * @brief Get minimum distance among all points
@@ -131,7 +136,12 @@ public:
      * @param parameter Pointer to parameter object used for calculating distance. 
      * @return Maximum distance.  
      */
-    double minDistance(uword total, DistanceParameter* parameter);
+    double minDistance();
+
+protected:
+
+    Parameter* mParameter = nullptr;
+
 };
 
 

--- a/include/gwmodelpp/spatialweight/CGwmDistance.h
+++ b/include/gwmodelpp/spatialweight/CGwmDistance.h
@@ -1,8 +1,9 @@
 #ifndef CGWMDISTANCE_H
 #define CGWMDISTANCE_H
 
-#include <unordered_map>
+#include <memory>
 #include <string>
+#include <unordered_map>
 #include <armadillo>
 #include <variant>
 
@@ -94,10 +95,7 @@ public:
      */
     virtual DistanceType type() = 0;
 
-    virtual Parameter* parameter() const
-    {
-        return mParameter;
-    }
+    virtual Parameter* parameter() const = delete;
 
 
 public:
@@ -107,9 +105,8 @@ public:
      * This function is pure virtual. It would never be called directly.
      * 
      * @param plist A list of parameters. 
-     * @return DistanceParameter* The pointer to parameters.
      */
-    virtual Parameter* makeParameter(initializer_list<DistParamVariant> plist) = 0;
+    virtual void makeParameter(initializer_list<DistParamVariant> plist) = 0;
 
     /**
      * @brief Calculate distance vector for a focus point. 
@@ -127,7 +124,7 @@ public:
      * @param parameter Pointer to parameter object used for calculating distance. 
      * @return Maximum distance. 
      */
-    double maxDistance();
+    virtual double maxDistance() = 0;
     
     /**
      * @brief Get minimum distance among all points
@@ -136,11 +133,7 @@ public:
      * @param parameter Pointer to parameter object used for calculating distance. 
      * @return Maximum distance.  
      */
-    double minDistance();
-
-protected:
-
-    Parameter* mParameter = nullptr;
+    virtual double minDistance() = 0;
 
 };
 

--- a/include/gwmodelpp/spatialweight/CGwmMinkwoskiDistance.h
+++ b/include/gwmodelpp/spatialweight/CGwmMinkwoskiDistance.h
@@ -29,7 +29,7 @@ public:
     void setTheta(double theta);
 
 public:
-    virtual vec distance(DistanceParameter* parameter, uword focus) override;
+    virtual vec distance(uword focus) override;
 
 private:
     double mPoly;

--- a/include/gwmodelpp/spatialweight/CGwmOneDimDistance.h
+++ b/include/gwmodelpp/spatialweight/CGwmOneDimDistance.h
@@ -4,33 +4,35 @@
 #include "CGwmDistance.h"
 
 /**
- * @brief Struct of parameters used in spatial distance calculating according to coordinate reference system. 
- * Usually a pointer to object of this class is passed to CGwmOneDimDistance::distance().
- */
-struct OneDimDistanceParameter : public DistanceParameter
-{
-    vec focusPoints;    //!< Matrix of focus points' coordinates. The shape of it must be nx2 and the first column is longitudes or x-coordinate, the second column is latitudes or y-coordinate.
-    vec dataPoints;     //!< Matrix of data points' coordinates. The shape of it must be nx2 and the first column is longitudes or x-coordinate, the second column is latitudes or y-coordinate.
-
-    /**
-     * @brief Construct a new OneDimDistanceParameter object.
-     * 
-     * @param fp Reference to focus points.
-     * @param dp Reference to data points.
-     */
-    OneDimDistanceParameter(const vec& fp, const vec& dp) : DistanceParameter()
-        , focusPoints(fp)
-        , dataPoints(dp)
-    {
-        total = fp.n_rows;
-    }
-};
-
-/**
  * @brief Class for calculating spatial distance according to coordinate reference system.
  */
 class CGwmOneDimDistance : public CGwmDistance
 {
+public:
+
+    /**
+     * @brief Struct of parameters used in spatial distance calculating according to coordinate reference system. 
+     * Usually a pointer to object of this class is passed to CGwmOneDimDistance::distance().
+     */
+    struct Parameter : public CGwmDistance::Parameter
+    {
+        vec focusPoints;    //!< Matrix of focus points' coordinates. The shape of it must be nx2 and the first column is longitudes or x-coordinate, the second column is latitudes or y-coordinate.
+        vec dataPoints;     //!< Matrix of data points' coordinates. The shape of it must be nx2 and the first column is longitudes or x-coordinate, the second column is latitudes or y-coordinate.
+
+        /**
+         * @brief Construct a new OneDimDistanceParameter object.
+         * 
+         * @param fp Reference to focus points.
+         * @param dp Reference to data points.
+         */
+        Parameter(const vec& fp, const vec& dp) : CGwmDistance::Parameter()
+            , focusPoints(fp)
+            , dataPoints(dp)
+        {
+            total = fp.n_rows;
+        }
+    };
+
 public:
 
     /**
@@ -84,9 +86,9 @@ public:
      * 
      * @return DistanceParameter* The pointer to parameters.
      */
-    virtual DistanceParameter* makeParameter(initializer_list<DistParamVariant> plist) override;
+    virtual CGwmDistance::Parameter* makeParameter(initializer_list<DistParamVariant> plist) override;
 
-    virtual vec distance(DistanceParameter* parameter, uword focus) override;
+    virtual vec distance(uword focus) override;
 };
 
 #endif // CGWMOneDimDISTANCE_H

--- a/include/gwmodelpp/spatialweight/CGwmOneDimDistance.h
+++ b/include/gwmodelpp/spatialweight/CGwmOneDimDistance.h
@@ -86,9 +86,14 @@ public:
      * 
      * @return DistanceParameter* The pointer to parameters.
      */
-    virtual CGwmDistance::Parameter* makeParameter(initializer_list<DistParamVariant> plist) override;
+    virtual void makeParameter(initializer_list<DistParamVariant> plist) override;
 
     virtual vec distance(uword focus) override;
+    virtual double maxDistance() override;
+    virtual double minDistance() override;
+
+protected:
+    unique_ptr<Parameter> mParameter = nullptr;
 };
 
 #endif // CGWMOneDimDISTANCE_H

--- a/include/gwmodelpp/spatialweight/CGwmSpatialWeight.h
+++ b/include/gwmodelpp/spatialweight/CGwmSpatialWeight.h
@@ -161,7 +161,7 @@ public:
      * @param focus 
      * @return vec 
      */
-    virtual vec weightVector(DistanceParameter* parameter, uword focus);
+    virtual vec weightVector(uword focus);
 
     /**
      * @brief Get whether this object is valid in geting weight vector.
@@ -252,9 +252,9 @@ inline void CGwmSpatialWeight::setDistance(CGwmDistance&& distance)
     mDistance = distance.clone();
 }
 
-inline vec CGwmSpatialWeight::weightVector(DistanceParameter* parameter, uword focus)
+inline vec CGwmSpatialWeight::weightVector(uword focus)
 {
-    return mWeight->weight(mDistance->distance(parameter, focus));
+    return mWeight->weight(mDistance->distance(focus));
 }
 
 #endif // CGWMSPATIALWEIGHT_H

--- a/include/gwmodelpp/spatialweight/CGwmSpatialWeight.h
+++ b/include/gwmodelpp/spatialweight/CGwmSpatialWeight.h
@@ -55,7 +55,10 @@ public:
      * 
      * @return Pointer to CGwmSpatialWeight::mWeight .
      */
-    CGwmWeight *weight() const;
+    CGwmWeight *weight() const
+    {
+        return mWeight;
+    }
 
     /**
      * @brief Set the pointer to CGwmSpatialWeight::mWeight object.
@@ -63,7 +66,11 @@ public:
      * @param weight Pointer to CGwmWeight instance. 
      * Control of this pointer will be taken, and it will be deleted when destructing.
      */
-    void setWeight(CGwmWeight *weight);
+    void setWeight(CGwmWeight *weight)
+    {
+        if (mWeight) delete mWeight;
+        mWeight = weight;
+    }
 
     /**
      * @brief Set the pointer to CGwmSpatialWeight::mWeight object.
@@ -71,7 +78,11 @@ public:
      * @param weight Reference to CGwmWeight instance.
      * This object will be cloned.
      */
-    void setWeight(CGwmWeight& weight);
+    void setWeight(CGwmWeight& weight)
+    {
+        if (mWeight) delete mWeight;
+        mWeight = weight.clone();
+    }
 
     /**
      * @brief Set the pointer to CGwmSpatialWeight::mWeight object.
@@ -79,7 +90,11 @@ public:
      * @param weight Reference to CGwmWeight instance.
      * This object will be cloned.
      */
-    void setWeight(CGwmWeight&& weight);
+    void setWeight(CGwmWeight&& weight)
+    {
+        if (mWeight) delete mWeight;
+        mWeight = weight.clone();
+    }
 
     /**
      * @brief Get the pointer to CGwmSpatialWeight::mWeight and cast it to required type.
@@ -95,7 +110,10 @@ public:
      * 
      * @return Pointer to CGwmSpatialWeight::mDistance.
      */
-    CGwmDistance *distance() const;
+    CGwmDistance *distance() const
+    {
+        return mDistance;
+    }
 
     /**
      * @brief Set the pointer to CGwmSpatialWeight::mDistance object.
@@ -103,7 +121,11 @@ public:
      * @param distance Pointer to CGwmDistance instance. 
      * Control of this pointer will be taken, and it will be deleted when destructing.
      */
-    void setDistance(CGwmDistance *distance);
+    void setDistance(CGwmDistance *distance)
+    {
+        if (mDistance) delete mDistance;
+        mDistance = distance;
+    }
 
     /**
      * @brief Set the pointer to CGwmSpatialWeight::mDistance object.
@@ -111,7 +133,11 @@ public:
      * @param distance Reference to CGwmDistance instance.
      * This object will be cloned.
      */
-    void setDistance(CGwmDistance& distance);
+    void setDistance(CGwmDistance& distance)
+    {
+        if (mDistance) delete mDistance;
+        mDistance = distance.clone();
+    }
 
     /**
      * @brief Set the pointer to CGwmSpatialWeight::mDistance object.
@@ -119,7 +145,11 @@ public:
      * @param distance Reference to CGwmDistance instance.
      * This object will be cloned.
      */
-    void setDistance(CGwmDistance&& distance);
+    void setDistance(CGwmDistance&& distance)
+    {
+        if (mDistance) delete mDistance;
+        mDistance = distance.clone();
+    }
 
     /**
      * @brief Get the pointer to CGwmSpatialWeight::mDistance and cast it to required type.
@@ -161,7 +191,10 @@ public:
      * @param focus 
      * @return vec 
      */
-    virtual vec weightVector(uword focus);
+    virtual vec weightVector(uword focus)
+    {
+        return mWeight->weight(mDistance->distance(focus));
+    }
 
     /**
      * @brief Get whether this object is valid in geting weight vector.
@@ -176,38 +209,10 @@ private:
     CGwmDistance* mDistance = nullptr;  //!< Pointer to distance configuration.
 };
 
-inline CGwmWeight *CGwmSpatialWeight::weight() const
-{
-    return mWeight;
-}
-
 template<>
 inline CGwmBandwidthWeight* CGwmSpatialWeight::weight<CGwmBandwidthWeight>() const
 {
     return static_cast<CGwmBandwidthWeight*>(mWeight);
-}
-
-inline void CGwmSpatialWeight::setWeight(CGwmWeight *weight)
-{
-    if (mWeight) delete mWeight;
-    mWeight = weight;
-}
-
-inline void CGwmSpatialWeight::setWeight(CGwmWeight& weight)
-{
-    if (mWeight) delete mWeight;
-    mWeight = weight.clone();
-}
-
-inline void CGwmSpatialWeight::setWeight(CGwmWeight&& weight)
-{
-    if (mWeight) delete mWeight;
-    mWeight = weight.clone();
-}
-
-inline CGwmDistance *CGwmSpatialWeight::distance() const
-{
-    return mDistance;
 }
 
 template<>
@@ -232,29 +237,6 @@ template<>
 inline CGwmOneDimDistance* CGwmSpatialWeight::distance<CGwmOneDimDistance>() const
 {
     return static_cast<CGwmOneDimDistance*>(mDistance);
-}
-
-inline void CGwmSpatialWeight::setDistance(CGwmDistance *distance)
-{
-    if (mDistance) delete mDistance;
-    mDistance = distance;
-}
-
-inline void CGwmSpatialWeight::setDistance(CGwmDistance& distance)
-{
-    if (mDistance) delete mDistance;
-    mDistance = distance.clone();
-}
-
-inline void CGwmSpatialWeight::setDistance(CGwmDistance&& distance)
-{
-    if (mDistance) delete mDistance;
-    mDistance = distance.clone();
-}
-
-inline vec CGwmSpatialWeight::weightVector(uword focus)
-{
-    return mWeight->weight(mDistance->distance(focus));
 }
 
 #endif // CGWMSPATIALWEIGHT_H

--- a/src/gwmodelpp/CGwmGWDR.cpp
+++ b/src/gwmodelpp/CGwmGWDR.cpp
@@ -27,11 +27,10 @@ void CGwmGWDR::run()
     // Set coordinates matrices.
     for (size_t m = 0; m < nDims; m++)
     {
-        DistanceParameter* oneDimDP = mSpatialWeights[m].distance()->makeParameter({
+        mSpatialWeights[m].distance()->makeParameter({
             vec(mSourceLayer->points().col(m)),
             vec(mSourceLayer->points().col(m))
         });
-        mDistParameters.push_back(oneDimDP);
     }
 
     // Select Independent Variable
@@ -57,8 +56,8 @@ void CGwmGWDR::run()
             const CGwmSpatialWeight& sw = mSpatialWeights[m];
             CGwmBandwidthWeight* bw = sw.weight<CGwmBandwidthWeight>();
             // Set Initial value
-            double lower = bw->adaptive() ? nVars + 1 : sw.distance()->minDistance(nDp, mDistParameters[m]);
-            double upper = bw->adaptive() ? nDp : sw.distance()->maxDistance(nDp, mDistParameters[m]);
+            double lower = bw->adaptive() ? nVars + 1 : sw.distance()->minDistance();
+            double upper = bw->adaptive() ? nDp : sw.distance()->maxDistance();
             if (bw->bandwidth() <= 0.0 || bw->bandwidth() >= upper)
             {
                 bw->setBandwidth(upper * 0.618);
@@ -99,7 +98,7 @@ void CGwmGWDR::run()
             vec w(nDp, arma::fill::ones);
             for (size_t m = 0; m < nDims; m++)
             {
-                w = w % mSpatialWeights[m].weightVector(mDistParameters[m], i);
+                w = w % mSpatialWeights[m].weightVector(i);
             }
             double tss = sum(dybar2 % w);
             double rss = sum(dyhat2 % w);
@@ -141,7 +140,7 @@ mat CGwmGWDR::regressionSerial(const mat& x, const vec& y)
         vec w(nDp, arma::fill::ones);
         for (size_t m = 0; m < nDim; m++)
         {
-            vec w_m = mSpatialWeights[m].weightVector(mDistParameters[m], i);
+            vec w_m = mSpatialWeights[m].weightVector(i);
             w = w % w_m;
         }
         mat ws(1, nVar, arma::fill::ones);
@@ -175,7 +174,7 @@ mat CGwmGWDR::regressionOmp(const mat& x, const vec& y)
             vec w(nDp, arma::fill::ones);
             for (size_t m = 0; m < nDim; m++)
             {
-                vec w_m = mSpatialWeights[m].weightVector(mDistParameters[m], i);
+                vec w_m = mSpatialWeights[m].weightVector(i);
                 w = w % w_m;
             }
             mat ws(1, nVar, arma::fill::ones);
@@ -211,7 +210,7 @@ mat CGwmGWDR::regressionHatmatrixSerial(const mat& x, const vec& y, mat& betasSE
         vec w(nDp, arma::fill::ones);
         for (size_t m = 0; m < nDim; m++)
         {
-            vec w_m = mSpatialWeights[m].weightVector(mDistParameters[m], i);
+            vec w_m = mSpatialWeights[m].weightVector(i);
             w = w % w_m;
         }
         mat ws(1, nVar, arma::fill::ones);
@@ -265,7 +264,7 @@ mat CGwmGWDR::regressionHatmatrixOmp(const mat& x, const vec& y, mat& betasSE, v
             vec w(nDp, arma::fill::ones);
             for (size_t m = 0; m < nDim; m++)
             {
-                vec w_m = mSpatialWeights[m].weightVector(mDistParameters[m], i);
+                vec w_m = mSpatialWeights[m].weightVector(i);
                 w = w % w_m;
             }
             mat ws(1, nVar, arma::fill::ones);
@@ -317,7 +316,7 @@ double CGwmGWDR::bandwidthCriterionCVSerial(const vector<CGwmBandwidthWeight*>& 
             vec w(nDp, arma::fill::ones);
             for (size_t m = 0; m < nDim; m++)
             {
-                vec d_m = mSpatialWeights[m].distance()->distance(mDistParameters[m], i);
+                vec d_m = mSpatialWeights[m].distance()->distance(i);
                 vec w_m = bandwidths[m]->weight(d_m);
                 w = w % w_m;
             }
@@ -357,7 +356,7 @@ double CGwmGWDR::bandwidthCriterionCVOmp(const vector<CGwmBandwidthWeight*>& ban
             vec w(nDp, arma::fill::ones);
             for (size_t m = 0; m < nDim; m++)
             {
-                vec d_m = mSpatialWeights[m].distance()->distance(mDistParameters[m], i);
+                vec d_m = mSpatialWeights[m].distance()->distance(i);
                 vec w_m = bandwidths[m]->weight(d_m);
                 w = w % w_m;
             }
@@ -398,7 +397,7 @@ double CGwmGWDR::bandwidthCriterionAICSerial(const vector<CGwmBandwidthWeight*>&
             vec w(nDp, arma::fill::ones);
             for (size_t m = 0; m < nDim; m++)
             {
-                vec d_m = mSpatialWeights[m].distance()->distance(mDistParameters[m], i);
+                vec d_m = mSpatialWeights[m].distance()->distance(i);
                 vec w_m = bandwidths[m]->weight(d_m);
                 w = w % w_m;
             }
@@ -442,7 +441,7 @@ double CGwmGWDR::bandwidthCriterionAICOmp(const vector<CGwmBandwidthWeight*>& ba
             vec w(nDp, arma::fill::ones);
             for (size_t m = 0; m < nDim; m++)
             {
-                vec d_m = mSpatialWeights[m].distance()->distance(mDistParameters[m], i);
+                vec d_m = mSpatialWeights[m].distance()->distance(i);
                 vec w_m = bandwidths[m]->weight(d_m);
                 w = w % w_m;
             }
@@ -522,7 +521,7 @@ double CGwmGWDR::indepVarCriterionSerial(const vector<GwmVariable>& indepVars)
                 vec w(nDp, arma::fill::ones);
                 for (size_t m = 0; m < nDim; m++)
                 {
-                    vec w_m = mSpatialWeights[m].weightVector(mDistParameters[m], i);
+                    vec w_m = mSpatialWeights[m].weightVector(i);
                     w = w % w_m;
                 }
                 mat xtw = (x.each_col() % w).t();
@@ -609,7 +608,7 @@ double CGwmGWDR::indepVarCriterionOmp(const vector<GwmVariable>& indepVars)
                 vec w(nDp, arma::fill::ones);
                 for (size_t m = 0; m < nDim; m++)
                 {
-                    vec w_m = mSpatialWeights[m].weightVector(mDistParameters[m], i);
+                    vec w_m = mSpatialWeights[m].weightVector(i);
                     w = w % w_m;
                 }
                 mat xtw = (x.each_col() % w).t();

--- a/src/gwmodelpp/CGwmGWPCA.cpp
+++ b/src/gwmodelpp/CGwmGWPCA.cpp
@@ -9,7 +9,6 @@ CGwmGWPCA::CGwmGWPCA()
 
 CGwmGWPCA::~CGwmGWPCA()
 {
-    delete mDistanceParameter;
 }
 
 void CGwmGWPCA::run()
@@ -49,7 +48,7 @@ mat CGwmGWPCA::solveSerial(const mat& x, cube& loadings, mat& sdev)
     loadings = cube(nDp, nVar, mK, arma::fill::zeros);
     for (uword i = 0; i < nDp; i++)
     {
-        vec w = mSpatialWeight.weightVector(mDistanceParameter, i);
+        vec w = mSpatialWeight.weightVector(i);
         mat V;
         vec d;
         wpca(x, w, V, d);

--- a/src/gwmodelpp/CGwmGWSS.cpp
+++ b/src/gwmodelpp/CGwmGWSS.cpp
@@ -130,7 +130,7 @@ void CGwmGWSS::summarySerial()
     uword corrSize = mIsCorrWithFirstOnly ? 1 : nVar - 1;
     for (uword i = 0; i < nRp; i++)
     {
-        vec w = mSpatialWeight.weightVector(mDistanceParameter, i);
+        vec w = mSpatialWeight.weightVector(i);
         double sumw = sum(w);
         vec Wi = w / sumw;
         mLocalMean.row(i) = trans(Wi) * mX;
@@ -182,7 +182,7 @@ void CGwmGWSS::summaryOmp()
     for (int i = 0; (uword)i < nRp; i++)
     {
         int thread = omp_get_thread_num();
-        vec w = mSpatialWeight.weightVector(mDistanceParameter, i);
+        vec w = mSpatialWeight.weightVector(i);
         double sumw = sum(w);
         vec Wi = w / sumw;
         mLocalMean.row(i) = trans(Wi) * mX;

--- a/src/gwmodelpp/CGwmSpatialMonoscaleAlgorithm.cpp
+++ b/src/gwmodelpp/CGwmSpatialMonoscaleAlgorithm.cpp
@@ -15,7 +15,7 @@ void CGwmSpatialMonoscaleAlgorithm::createDistanceParameter()
     if (mSpatialWeight.distance()->type() == CGwmDistance::DistanceType::CRSDistance || 
         mSpatialWeight.distance()->type() == CGwmDistance::DistanceType::MinkwoskiDistance)
     {
-        mDistanceParameter = mSpatialWeight.distance()->makeParameter({
+        mSpatialWeight.distance()->makeParameter({
             mSourceLayer->points(),
             mSourceLayer->points()
         });

--- a/src/gwmodelpp/spatialweight/CGwmCRSDistance.cpp
+++ b/src/gwmodelpp/spatialweight/CGwmCRSDistance.cpp
@@ -89,21 +89,23 @@ CGwmCRSDistance::CGwmCRSDistance(const CGwmCRSDistance &distance) : CGwmDistance
     mGeographic = distance.mGeographic;
 }
 
-DistanceParameter* CGwmCRSDistance::makeParameter(initializer_list<DistParamVariant> plist)
+CGwmDistance::Parameter* CGwmCRSDistance::makeParameter(initializer_list<DistParamVariant> plist)
 {
+    if (mParameter != nullptr) delete mParameter;
     if (plist.size() == 2)
     {
         const mat& fp = get<mat>(*(plist.begin()));
         const mat& dp = get<mat>(*(plist.begin() + 1));
-        return new CRSDistanceParameter(fp, dp);
+        mParameter = new Parameter(fp, dp);
     }
-    else return nullptr;
+    else mParameter = nullptr;
+    return mParameter;
 }
 
-vec CGwmCRSDistance::distance(DistanceParameter* parameter, uword focus)
+vec CGwmCRSDistance::distance(uword focus)
 {
-    assert(parameter != nullptr);
-    CRSDistanceParameter* p = static_cast<CRSDistanceParameter*>(parameter);
+    assert(mParameter != nullptr);
+    Parameter* p = static_cast<Parameter*>(mParameter);
     if (p->dataPoints.n_cols == 2 && p->focusPoints.n_cols == 2)
     {
         if (focus < p->total)

--- a/src/gwmodelpp/spatialweight/CGwmCRSDistance.cpp
+++ b/src/gwmodelpp/spatialweight/CGwmCRSDistance.cpp
@@ -73,20 +73,25 @@ vec CGwmCRSDistance::SpatialDistance(const rowvec &out_loc, const mat &in_locs)
     return dists;
 }
 
-CGwmCRSDistance::CGwmCRSDistance() : CGwmDistance()
+CGwmCRSDistance::CGwmCRSDistance() : mParameter(nullptr)
 {
 
 }
 
-CGwmCRSDistance::CGwmCRSDistance(bool isGeographic) : CGwmDistance()
+CGwmCRSDistance::CGwmCRSDistance(bool isGeographic): mParameter(nullptr), mGeographic(isGeographic)
 {
-    mGeographic = isGeographic;
     mCalculator = mGeographic ? &SpatialDistance : &EuclideanDistance;
 }
 
 CGwmCRSDistance::CGwmCRSDistance(const CGwmCRSDistance &distance) : CGwmDistance(distance)
 {
     mGeographic = distance.mGeographic;
+    if (distance.mParameter)
+    {
+        mat fp = distance.mParameter->focusPoints;
+        mat dp = distance.mParameter->dataPoints;
+        mParameter = make_unique<Parameter>(fp, dp);
+    }
 }
 
 void CGwmCRSDistance::makeParameter(initializer_list<DistParamVariant> plist)

--- a/src/gwmodelpp/spatialweight/CGwmDMatDistance.cpp
+++ b/src/gwmodelpp/spatialweight/CGwmDMatDistance.cpp
@@ -1,12 +1,12 @@
 #include "gwmodelpp/spatialweight/CGwmDMatDistance.h"
 #include <assert.h>
 
-CGwmDMatDistance::CGwmDMatDistance(string dmatFile) : CGwmDistance()
+CGwmDMatDistance::CGwmDMatDistance(string dmatFile)
 {
     mDMatFile = dmatFile;
 }
 
-CGwmDMatDistance::CGwmDMatDistance(const CGwmDMatDistance &distance) : CGwmDistance(distance)
+CGwmDMatDistance::CGwmDMatDistance(const CGwmDMatDistance &distance)
 {
     mDMatFile = distance.mDMatFile;
 }

--- a/src/gwmodelpp/spatialweight/CGwmDMatDistance.cpp
+++ b/src/gwmodelpp/spatialweight/CGwmDMatDistance.cpp
@@ -11,22 +11,20 @@ CGwmDMatDistance::CGwmDMatDistance(const CGwmDMatDistance &distance) : CGwmDista
     mDMatFile = distance.mDMatFile;
 }
 
-CGwmDistance::Parameter* CGwmDMatDistance::makeParameter(initializer_list<DistParamVariant> plist)
+void CGwmDMatDistance::makeParameter(initializer_list<DistParamVariant> plist)
 {
-    if (mParameter != nullptr) delete mParameter;
     if (plist.size() == 2)
     {
         const uword size = get<uword>(*(plist.begin()));
         const uword rows = get<uword>(*(plist.begin() + 1));
-        mParameter = new Parameter(size, rows);
+        mParameter = make_unique<Parameter>(size, rows);
     }
     else mParameter = nullptr;
-    return mParameter;
 }
 
 vec CGwmDMatDistance::distance(uword focus)
 {
-    assert(mParameter != nullptr);
+    if(mParameter == nullptr) throw std::runtime_error("Parameter is nullptr.");
     // QFile dmat(mDMatFile);
     // if (focus < mTotal && dmat.open(QFile::QIODevice::ReadOnly))
     // {
@@ -36,4 +34,16 @@ vec CGwmDMatDistance::distance(uword focus)
     //     return vec((double*)values.data(), mRowSize);
     // }
     return vec();
+}
+
+double CGwmDMatDistance::maxDistance()
+{
+    if(mParameter == nullptr) throw std::runtime_error("Parameter is nullptr.");
+    return DBL_MAX;
+}
+
+double CGwmDMatDistance::minDistance()
+{
+    if(mParameter == nullptr) throw std::runtime_error("Parameter is nullptr.");
+    return 0.0;
 }

--- a/src/gwmodelpp/spatialweight/CGwmDMatDistance.cpp
+++ b/src/gwmodelpp/spatialweight/CGwmDMatDistance.cpp
@@ -11,20 +11,22 @@ CGwmDMatDistance::CGwmDMatDistance(const CGwmDMatDistance &distance) : CGwmDista
     mDMatFile = distance.mDMatFile;
 }
 
-DistanceParameter* CGwmDMatDistance::makeParameter(initializer_list<DistParamVariant> plist)
+CGwmDistance::Parameter* CGwmDMatDistance::makeParameter(initializer_list<DistParamVariant> plist)
 {
+    if (mParameter != nullptr) delete mParameter;
     if (plist.size() == 2)
     {
         const uword size = get<uword>(*(plist.begin()));
         const uword rows = get<uword>(*(plist.begin() + 1));
-        return new DMatDistanceParameter(size, rows);
+        mParameter = new Parameter(size, rows);
     }
-    else return nullptr;
+    else mParameter = nullptr;
+    return mParameter;
 }
 
-vec CGwmDMatDistance::distance(DistanceParameter* parameter, uword focus)
+vec CGwmDMatDistance::distance(uword focus)
 {
-    assert(parameter != nullptr);
+    assert(mParameter != nullptr);
     // QFile dmat(mDMatFile);
     // if (focus < mTotal && dmat.open(QFile::QIODevice::ReadOnly))
     // {

--- a/src/gwmodelpp/spatialweight/CGwmDistance.cpp
+++ b/src/gwmodelpp/spatialweight/CGwmDistance.cpp
@@ -8,25 +8,25 @@ unordered_map<CGwmDistance::DistanceType, string> CGwmDistance::TypeNameMapper =
     std::make_pair(CGwmDistance::DistanceType::DMatDistance, "DMatDistance")
 };
 
-double CGwmDistance::maxDistance(uword total, DistanceParameter* parameter)
+double CGwmDistance::maxDistance()
 {
-    assert(parameter != nullptr);
+    assert(mParameter != nullptr);
     double maxD = 0.0;
-    for (uword i = 0; i < total; i++)
+    for (uword i = 0; i < mParameter->total; i++)
     {
-        double d = max(distance(parameter, i));
+        double d = max(distance(i));
         maxD = d > maxD ? d : maxD;
     }
     return maxD;
 }
 
-double CGwmDistance::minDistance(uword total, DistanceParameter* parameter)
+double CGwmDistance::minDistance()
 {
-    assert(parameter != nullptr);
+    assert(mParameter != nullptr);
     double minD = DBL_MAX;
-    for (uword i = 0; i < total; i++)
+    for (uword i = 0; i < mParameter->total; i++)
     {
-        double d = min(distance(parameter, i));
+        double d = min(distance(i));
         minD = d < minD ? d : minD;
     }
     return minD;

--- a/src/gwmodelpp/spatialweight/CGwmDistance.cpp
+++ b/src/gwmodelpp/spatialweight/CGwmDistance.cpp
@@ -7,27 +7,3 @@ unordered_map<CGwmDistance::DistanceType, string> CGwmDistance::TypeNameMapper =
     std::make_pair(CGwmDistance::DistanceType::MinkwoskiDistance, "MinkwoskiDistance"),
     std::make_pair(CGwmDistance::DistanceType::DMatDistance, "DMatDistance")
 };
-
-double CGwmDistance::maxDistance()
-{
-    assert(mParameter != nullptr);
-    double maxD = 0.0;
-    for (uword i = 0; i < mParameter->total; i++)
-    {
-        double d = max(distance(i));
-        maxD = d > maxD ? d : maxD;
-    }
-    return maxD;
-}
-
-double CGwmDistance::minDistance()
-{
-    assert(mParameter != nullptr);
-    double minD = DBL_MAX;
-    for (uword i = 0; i < mParameter->total; i++)
-    {
-        double d = min(distance(i));
-        minD = d < minD ? d : minD;
-    }
-    return minD;
-}

--- a/src/gwmodelpp/spatialweight/CGwmMinkwoskiDistance.cpp
+++ b/src/gwmodelpp/spatialweight/CGwmMinkwoskiDistance.cpp
@@ -24,28 +24,24 @@ mat CGwmMinkwoskiDistance::CoordinateRotate(const mat& coords, double theta)
 
 vec CGwmMinkwoskiDistance::distance(uword focus)
 {
-    assert(mParameter != nullptr);
+    if(mParameter == nullptr) throw std::runtime_error("Parameter is nullptr.");
+
     if (mGeographic) return CGwmCRSDistance::distance(focus);
     else
     {
-        CGwmCRSDistance::Parameter* p = static_cast<CGwmCRSDistance::Parameter*>(mParameter);
-        if (p->dataPoints.n_cols == 2 && p->focusPoints.n_cols == 2)
+        if (focus < mParameter->total)
         {
-            if (focus < p->total)
+            mat dp = mParameter->dataPoints;
+            rowvec rp = mParameter->focusPoints.row(focus);
+            if (mPoly != 2 && mTheta != 0)
             {
-                mat dp = p->dataPoints;
-                rowvec rp = p->focusPoints.row(focus);
-                if (mPoly != 2 && mTheta != 0)
-                {
-                    dp = CoordinateRotate(p->dataPoints, mTheta);
-                    rp = CoordinateRotate(p->focusPoints.row(focus), mTheta);
-                }
-                if (mPoly == 1.0) return ChessDistance(rp, dp);
-                else if (mPoly == -1.0) return ManhattonDistance(rp, dp);
-                else return MinkwoskiDistance(rp, dp, mPoly);
+                dp = CoordinateRotate(mParameter->dataPoints, mTheta);
+                rp = CoordinateRotate(mParameter->focusPoints.row(focus), mTheta);
             }
-            else throw std::runtime_error("Target is out of bounds of data points.");
+            if (mPoly == 1.0) return ChessDistance(rp, dp);
+            else if (mPoly == -1.0) return ManhattonDistance(rp, dp);
+            else return MinkwoskiDistance(rp, dp, mPoly);
         }
-        else throw std::runtime_error("The dimension of data points or focus points is not 2.");
+        else throw std::runtime_error("Target is out of bounds of data points.");
     }
 }

--- a/src/gwmodelpp/spatialweight/CGwmMinkwoskiDistance.cpp
+++ b/src/gwmodelpp/spatialweight/CGwmMinkwoskiDistance.cpp
@@ -22,13 +22,13 @@ mat CGwmMinkwoskiDistance::CoordinateRotate(const mat& coords, double theta)
     return rotated_coords;
 }
 
-vec CGwmMinkwoskiDistance::distance(DistanceParameter* parameter, uword focus)
+vec CGwmMinkwoskiDistance::distance(uword focus)
 {
-    assert(parameter != nullptr);
-    if (mGeographic) return CGwmCRSDistance::distance(parameter, focus);
+    assert(mParameter != nullptr);
+    if (mGeographic) return CGwmCRSDistance::distance(focus);
     else
     {
-        CRSDistanceParameter* p = (CRSDistanceParameter*)parameter;
+        CGwmCRSDistance::Parameter* p = static_cast<CGwmCRSDistance::Parameter*>(mParameter);
         if (p->dataPoints.n_cols == 2 && p->focusPoints.n_cols == 2)
         {
             if (focus < p->total)

--- a/src/gwmodelpp/spatialweight/CGwmOneDimDistance.cpp
+++ b/src/gwmodelpp/spatialweight/CGwmOneDimDistance.cpp
@@ -14,21 +14,23 @@ CGwmOneDimDistance::CGwmOneDimDistance(const CGwmOneDimDistance &distance) : CGw
     
 }
 
-DistanceParameter* CGwmOneDimDistance::makeParameter(initializer_list<DistParamVariant> plist)
+CGwmDistance::Parameter* CGwmOneDimDistance::makeParameter(initializer_list<DistParamVariant> plist)
 {
+    if (mParameter != nullptr) delete mParameter;
     if (plist.size() == 2)
     {
         const mat& fp = get<vec>(*(plist.begin()));
         const mat& dp = get<vec>(*(plist.begin() + 1));
-        return new OneDimDistanceParameter(fp, dp);
+        mParameter = new Parameter(fp, dp);
     }
-    else return nullptr;
+    else mParameter = nullptr;
+    return mParameter;
 }
 
-vec CGwmOneDimDistance::distance(DistanceParameter* parameter, uword focus)
+vec CGwmOneDimDistance::distance(uword focus)
 {
-    assert(parameter != nullptr);
-    OneDimDistanceParameter* p = (OneDimDistanceParameter*)parameter;
+    assert(mParameter != nullptr);
+    Parameter* p = static_cast<Parameter*>(mParameter);
     if (focus < p->total)
     {
         return AbstractDistance(p->focusPoints(focus), p->dataPoints);

--- a/src/gwmodelpp/spatialweight/CGwmOneDimDistance.cpp
+++ b/src/gwmodelpp/spatialweight/CGwmOneDimDistance.cpp
@@ -14,26 +14,52 @@ CGwmOneDimDistance::CGwmOneDimDistance(const CGwmOneDimDistance &distance) : CGw
     
 }
 
-CGwmDistance::Parameter* CGwmOneDimDistance::makeParameter(initializer_list<DistParamVariant> plist)
+void CGwmOneDimDistance::makeParameter(initializer_list<DistParamVariant> plist)
 {
-    if (mParameter != nullptr) delete mParameter;
     if (plist.size() == 2)
     {
         const mat& fp = get<vec>(*(plist.begin()));
         const mat& dp = get<vec>(*(plist.begin() + 1));
-        mParameter = new Parameter(fp, dp);
+        mParameter = make_unique<Parameter>(fp, dp);
     }
-    else mParameter = nullptr;
-    return mParameter;
+    else
+    {
+        mParameter.reset(nullptr);
+        throw std::runtime_error("The number of parameters must be 2.");
+    }
 }
 
 vec CGwmOneDimDistance::distance(uword focus)
 {
-    assert(mParameter != nullptr);
-    Parameter* p = static_cast<Parameter*>(mParameter);
-    if (focus < p->total)
+    if (mParameter == nullptr) throw std::runtime_error("Parameter is nullptr.");
+
+    if (focus < mParameter->total)
     {
-        return AbstractDistance(p->focusPoints(focus), p->dataPoints);
+        return AbstractDistance(mParameter->focusPoints(focus), mParameter->dataPoints);
     }
     else throw std::runtime_error("Target is out of bounds of data points.");
+}
+
+double CGwmOneDimDistance::maxDistance()
+{
+    if (mParameter == nullptr) throw std::runtime_error("Parameter is nullptr.");
+    double maxD = 0.0;
+    for (uword i = 0; i < mParameter->total; i++)
+    {
+        double d = max(AbstractDistance(mParameter->focusPoints(i), mParameter->dataPoints));
+        maxD = d > maxD ? d : maxD;
+    }
+    return maxD;
+}
+
+double CGwmOneDimDistance::minDistance()
+{
+    if (mParameter == nullptr) throw std::runtime_error("Parameter is nullptr.");
+    double minD = DBL_MAX;
+    for (uword i = 0; i < mParameter->total; i++)
+    {
+        double d = min(AbstractDistance(mParameter->focusPoints(i), mParameter->dataPoints));
+        minD = d < minD ? d : minD;
+    }
+    return minD;
 }


### PR DESCRIPTION
CHANGELOG

1. 删除 CGwmDistance 中的 mParameter 成员函数，将其完全变成一个类似于接口的抽象基类。下一步可以进一步改成接口。
2. 将 `maxDistance` 和 `minDistance` 转换为纯虚函数，由各个类自行实现，以减少函数调用开销。
3. 将各距离类型的参数放置在内部的 Parameter 类型中，由各类自行实现的 `makeParameter` 进行构造。
4. 将 mParameter 的类型统一改为了 `std::unique_ptr` 确保唯一控制权。
5. 删除了 CGwmDistance 的构造函数，因为其无法构造。
6. 修改了 CGwmCRSDistance 复制构造函数中没有复制 mParameter 的问题。