### PR TITLE
Let compiler show more warnings

### DIFF
--- a/include/gwmodelpp/CGwmGWDR.h
+++ b/include/gwmodelpp/CGwmGWDR.h
@@ -125,7 +125,7 @@ public: // IGwmRegressionAnalysis
 
     virtual GwmRegressionDiagnostic diagnostic() const override { return mDiagnostic; }
 
-    virtual mat predict(const mat& locations) override { return mat(); }
+    virtual mat predict(const mat& locations) override { return mat(locations.n_rows, mX.n_cols, arma::fill::zeros); }
 
     virtual mat fit() override;
 

--- a/include/gwmodelpp/CGwmGWSS.h
+++ b/include/gwmodelpp/CGwmGWSS.h
@@ -84,7 +84,7 @@ public:
         return covwt(x1,x2,w)/sqrt(covwt(x1,x1,w)*covwt(x2,x2,w));
     }
 
-    static vec del(vec x,int rowcount);
+    static vec del(vec x, uword rowcount);
 
     static vec rank(vec x)
     {

--- a/include/gwmodelpp/CGwmMGWR.h
+++ b/include/gwmodelpp/CGwmMGWR.h
@@ -39,7 +39,7 @@ public:
 
     typedef double (CGwmMGWR::*BandwidthSizeCriterionFunction)(CGwmBandwidthWeight*);
     typedef mat (CGwmMGWR::*FitAllFunction)(const arma::mat&, const arma::vec&);
-    typedef vec (CGwmMGWR::*FitVarFunction)(const arma::vec&, const arma::vec&, const uword, mat&);
+    typedef vec (CGwmMGWR::*FitVarFunction)(const arma::vec&, const arma::vec&, const arma::uword, mat&);
     typedef mat (CGwmMGWR::*FitCalculator)(const mat&, const vec&, mat&, vec&, vec&, mat&);
 
 private:

--- a/include/gwmodelpp/CGwmMGWR.h
+++ b/include/gwmodelpp/CGwmMGWR.h
@@ -39,7 +39,7 @@ public:
 
     typedef double (CGwmMGWR::*BandwidthSizeCriterionFunction)(CGwmBandwidthWeight*);
     typedef mat (CGwmMGWR::*FitAllFunction)(const arma::mat&, const arma::vec&);
-    typedef vec (CGwmMGWR::*FitVarFunction)(const arma::vec&, const arma::vec&, int, mat&);
+    typedef vec (CGwmMGWR::*FitVarFunction)(const arma::vec&, const arma::vec&, const uword, mat&);
     typedef mat (CGwmMGWR::*FitCalculator)(const mat&, const vec&, mat&, vec&, vec&, mat&);
 
 private:
@@ -56,7 +56,7 @@ private:
 
     static double AICc(const mat& x, const mat& y, const mat& betas, const vec& shat)
     {
-        double ss = RSS(x, y, betas), n = x.n_rows;
+        double ss = RSS(x, y, betas), n = (double)x.n_rows;
         return n * log(ss / n) + n * log(2 * datum::pi) + n * ((n + shat(0)) / (n - 2 - shat(0)));
     }
     bool isStoreS()
@@ -100,11 +100,11 @@ public:
     bool hasHatMatrix() const { return mHasHatMatrix; }
     void setHasHatMatrix(bool hasHatMatrix) { mHasHatMatrix = hasHatMatrix; }
 
-    int bandwidthSelectRetryTimes() const {return mBandwidthSelectRetryTimes; }
-    void setBandwidthSelectRetryTimes(int bandwidthSelectRetryTimes) {mBandwidthSelectRetryTimes = bandwidthSelectRetryTimes; }
+    size_t bandwidthSelectRetryTimes() const { return (size_t)mBandwidthSelectRetryTimes; }
+    void setBandwidthSelectRetryTimes(size_t bandwidthSelectRetryTimes) { mBandwidthSelectRetryTimes = (uword)bandwidthSelectRetryTimes; }
 
-    int maxIteration() const { return mMaxIteration; }
-    void setMaxIteration(int maxIteration) { mMaxIteration = maxIteration; }
+    size_t maxIteration() const { return mMaxIteration; }
+    void setMaxIteration(size_t maxIteration) { mMaxIteration = maxIteration; }
 
     BackFittingCriterionType criterionType() const { return mCriterionType; }
     void setCriterionType(const BackFittingCriterionType &criterionType) { mCriterionType = criterionType; }
@@ -157,7 +157,7 @@ public:     // IRegressionAnalysis interface
 
     virtual GwmRegressionDiagnostic diagnostic() const override { return mDiagnostic; }
 
-    mat predict(const mat& coords) override { return mat(); }
+    mat predict(const mat& locations) override { return mat(locations.n_rows, mX.n_cols, arma::fill::zeros); }
 
     mat fit() override;
 
@@ -182,7 +182,7 @@ public:     // IOpenmpParallelable interface
 
 protected:
 
-    CGwmBandwidthWeight* bandwidth(int i)
+    CGwmBandwidthWeight* bandwidth(size_t i)
     {
         return static_cast<CGwmBandwidthWeight*>(mSpatialWeights[i].weight());
     }
@@ -191,9 +191,9 @@ protected:
 
     mat fitAllOmp(const mat& x, const vec& y);
 
-    vec fitVarSerial(const vec& x, const vec& y, const int var, mat& S);
+    vec fitVarSerial(const vec& x, const vec& y, const uword var, mat& S);
 
-    vec fitVarOmp(const vec& x, const vec& y, const int var, mat& S);
+    vec fitVarOmp(const vec& x, const vec& y, const uword var, mat& S);
 
     mat backfitting(const mat &x, const vec &y);
 
@@ -217,16 +217,13 @@ protected:
 
     void createInitialDistanceParameter();
 
-protected:
-    CGwmBandwidthSelector mselector;
-
 private:
     FitAllFunction mFitAll = &CGwmMGWR::fitAllSerial;
     FitVarFunction mFitVar = &CGwmMGWR::fitVarSerial;
 
     CGwmSpatialWeight mInitSpatialWeight;
     BandwidthSizeCriterionFunction mBandwidthSizeCriterion = &CGwmMGWR::bandwidthSizeCriterionAllCVSerial;
-    int mBandwidthSelectionCurrentIndex = 0;
+    size_t mBandwidthSelectionCurrentIndex = 0;
 
 
     vector<BandwidthInitilizeType> mBandwidthInitilize;
@@ -234,7 +231,7 @@ private:
     vector<bool> mPreditorCentered;
     vector<double> mBandwidthSelectThreshold;
     uword mBandwidthSelectRetryTimes = 5;
-    int mMaxIteration = 500;
+    size_t mMaxIteration = 500;
     BackFittingCriterionType mCriterionType = BackFittingCriterionType::dCVR;
     double mCriterionThreshold = 1e-6;
     int mAdaptiveLower = 10;

--- a/include/gwmodelpp/spatialweight/CGwmCRSDistance.h
+++ b/include/gwmodelpp/spatialweight/CGwmCRSDistance.h
@@ -73,14 +73,17 @@ private:
 
 public:
 
-    CGwmCRSDistance();
+    CGwmCRSDistance() : mGeographic(false), mParameter(nullptr) {}
 
     /**
      * @brief Construct a new CGwmCRSDistance object
      * 
      * @param isGeographic Whether the coordinate reference system is geographical.
      */
-    explicit CGwmCRSDistance(bool isGeographic);
+    explicit CGwmCRSDistance(bool isGeographic): mGeographic(isGeographic), mParameter(nullptr)
+    {
+        mCalculator = mGeographic ? &SpatialDistance : &EuclideanDistance;
+    }
 
     /**
      * @brief Copy construct a new CGwmCRSDistance object.
@@ -137,8 +140,8 @@ public:
     virtual double minDistance() override;
 
 protected:
-    bool mGeographic = false;
-    unique_ptr<Parameter> mParameter = nullptr;
+    bool mGeographic;
+    unique_ptr<Parameter> mParameter;
 
 private:
     CalculatorType mCalculator = &EuclideanDistance;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -101,20 +101,14 @@ if(CMAKE_BUILD_TYPE STREQUAL Debug)
     $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
         -Wall -Werror>
     $<$<CXX_COMPILER_ID:MSVC>:
-        /W4 /WX>)
+        /W4 /wd4819 /WX>)
 else()
     target_compile_options(gwmodel PRIVATE
     $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
         -Wall>
     $<$<CXX_COMPILER_ID:MSVC>:
-        /W4>)
+        /W4 /wd4819>)
 endif()
-
-target_compile_options(gwmodel PRIVATE
-    $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
-        -Wall>
-    $<$<CXX_COMPILER_ID:MSVC>:
-        /W4>)
 
 target_link_libraries(gwmodel
     ${ARMADILLO_LIBRARIES}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -96,6 +96,26 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${gwmodel_BINARY_DIR}/bin)
 add_library(gwmodel STATIC ${SOURCES_CXX} ${HEADERS_CXX} ${HEADERS_C})
 set_property(TARGET gwmodel PROPERTY POSITION_INDEPENDENT_CODE ON)
 
+if(CMAKE_BUILD_TYPE STREQUAL Debug)
+    target_compile_options(gwmodel PRIVATE
+    $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
+        -Wall -Werror>
+    $<$<CXX_COMPILER_ID:MSVC>:
+        /W4 /WX>)
+else()
+    target_compile_options(gwmodel PRIVATE
+    $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
+        -Wall>
+    $<$<CXX_COMPILER_ID:MSVC>:
+        /W4>)
+endif()
+
+target_compile_options(gwmodel PRIVATE
+    $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
+        -Wall>
+    $<$<CXX_COMPILER_ID:MSVC>:
+        /W4>)
+
 target_link_libraries(gwmodel
     ${ARMADILLO_LIBRARIES}
     ${BLAS_LIBRARIES}

--- a/src/gwmodelpp/CGwmGWDR.cpp
+++ b/src/gwmodelpp/CGwmGWDR.cpp
@@ -533,6 +533,7 @@ double CGwmGWDR::indepVarCriterionSerial(const vector<size_t>& indepVars)
                 }
                 catch (std::exception& e)
                 {
+                    GWM_LOG_ERROR(e.what());
                     success = false;
                 }
             }
@@ -610,6 +611,7 @@ double CGwmGWDR::indepVarCriterionOmp(const vector<size_t>& indepVars)
                 }
                 catch (std::exception& e)
                 {
+                    GWM_LOG_ERROR(e.what());
                     success = false;
                 }
             }

--- a/src/gwmodelpp/CGwmGWDR.cpp
+++ b/src/gwmodelpp/CGwmGWDR.cpp
@@ -148,7 +148,7 @@ mat CGwmGWDR::predictOmp(const mat& locations, const mat& x, const vec& y)
     bool success = true;
     std::exception except;
 #pragma omp parallel for num_threads(mOmpThreadNum)
-    for (int i = 0; i < nDp; i++)
+    for (int i = 0; (uword)i < nDp; i++)
     {
         if (success)
         {
@@ -245,7 +245,7 @@ mat CGwmGWDR::fitOmp(const mat& x, const vec& y, mat& betasSE, vec& shat, vec& q
     bool success = true;
     std::exception except;
 #pragma omp parallel for num_threads(mOmpThreadNum)
-    for (int i = 0; i < nDp; i++)
+    for (int i = 0; (uword)i < nDp; i++)
     {
         int thread = omp_get_thread_num();
         if (success)
@@ -429,7 +429,7 @@ double CGwmGWDR::bandwidthCriterionAICOmp(const vector<CGwmBandwidthWeight*>& ba
     bool success = true;
     std::exception except;
 #pragma omp parallel for num_threads(mOmpThreadNum)
-    for (int i = 0; i < nDp; i++)
+    for (int i = 0; (uword)i < nDp; i++)
     {
         int thread = omp_get_thread_num();
         if (success)
@@ -586,7 +586,7 @@ double CGwmGWDR::indepVarCriterionOmp(const vector<size_t>& indepVars)
     {
         vec trS_all(mOmpThreadNum, arma::fill::zeros);
 #pragma omp parallel for num_threads(mOmpThreadNum)
-        for (int i = 0; i < nDp; i++)
+        for (int i = 0; (uword)i < nDp; i++)
         {
             int thread = omp_get_thread_num();
             if (success)
@@ -724,15 +724,13 @@ const int CGwmGWDRBandwidthOptimizer::optimize(CGwmGWDR* instance, uword feature
     }
     Parameter params = { instance, &mBandwidths, featureCount };
     gsl_multimin_function function = { criterion_function, nDim, &params };
-    double criterion = DBL_MAX;
     int status = gsl_multimin_fminimizer_set(minimizer, &function, targets, steps);
     if (status == GSL_SUCCESS)
     {
-        int iter = 0;
-        double size = DBL_MAX, size0 = DBL_MAX;
+        size_t iter = 0;
+        double size = DBL_MAX;
         do
         {
-            size0 = size;
             iter++;
             status = gsl_multimin_fminimizer_iterate(minimizer);
             if (status)

--- a/src/gwmodelpp/CGwmGWSS.cpp
+++ b/src/gwmodelpp/CGwmGWSS.cpp
@@ -5,14 +5,14 @@
 #include <omp.h>
 #endif
 
-vec CGwmGWSS::del(vec x, int rowcount){
+vec CGwmGWSS::del(vec x, uword rowcount){
     vec res;
-    if(rowcount == 0)
-        res = x.rows(rowcount+1,x.n_rows-1);
-    else if(rowcount == x.n_rows-1)
+    if (rowcount == 0)
+        res = x.rows(rowcount + 1, x.n_rows - 1);
+    else if (rowcount == x.n_rows - 1)
         res = x.rows(0,x.n_rows-2);
     else
-        res = join_cols(x.rows(0,rowcount - 1),x.rows(rowcount+1,x.n_rows-1));
+        res = join_cols(x.rows(0,rowcount - 1),x.rows(rowcount + 1, x.n_rows - 1));
     return res;
 }
 
@@ -139,7 +139,6 @@ void CGwmGWSS::summaryOmp()
 #pragma omp parallel for num_threads(mOmpThreadNum)
     for (int i = 0; (uword)i < nRp; i++)
     {
-        int thread = omp_get_thread_num();
         vec w = mSpatialWeight.weightVector(i);
         double sumw = sum(w);
         vec Wi = w / sumw;

--- a/src/gwmodelpp/CGwmMGWR.cpp
+++ b/src/gwmodelpp/CGwmMGWR.cpp
@@ -167,7 +167,7 @@ mat CGwmMGWR::backfitting(const mat &x, const vec &y)
     vec resid = y - Fitted(x, betas);
     double RSS0 = sum(resid % resid), RSS1 = DBL_MAX;
     double criterion = DBL_MAX;
-    for (int iteration = 1; iteration <= mMaxIteration && criterion > mCriterionThreshold; iteration++)
+    for (size_t iteration = 1; iteration <= mMaxIteration && criterion > mCriterionThreshold; iteration++)
     {
         for (uword i = 0; i < nVar  ; i++)
         {

--- a/src/gwmodelpp/CGwmMGWR.cpp
+++ b/src/gwmodelpp/CGwmMGWR.cpp
@@ -230,7 +230,7 @@ bool CGwmMGWR::isValid()
     if (!(mX.n_cols > 0))
         return false;
 
-    int nVar = mX.n_cols;
+    size_t nVar = mX.n_cols;
 
     if (mSpatialWeights.size() != nVar)
         return false;
@@ -247,7 +247,7 @@ bool CGwmMGWR::isValid()
     if (mBandwidthSelectThreshold.size() != nVar)
         return false;
 
-    for (int i = 0; i < nVar; i++)
+    for (size_t i = 0; i < nVar; i++)
     {
         CGwmBandwidthWeight* bw = mSpatialWeights[i].weight<CGwmBandwidthWeight>();
         if (mBandwidthInitilize[i] == CGwmMGWR::Specified || mBandwidthInitilize[i] == CGwmMGWR::Initial)
@@ -275,7 +275,7 @@ mat CGwmMGWR::fitAllSerial(const mat& x, const vec& y)
     if (mHasHatMatrix )
     {
         mat betasSE(nVar, nDp, fill::zeros);
-        for (int i = 0; i < nDp ; i++)
+        for (int i = 0; (uword)i < nDp ; i++)
         {
             vec w = mInitSpatialWeight.weightVector(i);
             mat xtw = trans(x.each_col() % w);
@@ -291,7 +291,7 @@ mat CGwmMGWR::fitAllSerial(const mat& x, const vec& y)
                 mS0.row(i) = si;
                 mC.slice(i) = ci;
             }
-            catch (exception e)
+            catch (const exception& e)
             {
                 GWM_LOG_ERROR(e.what());
                 throw e;
@@ -301,7 +301,7 @@ mat CGwmMGWR::fitAllSerial(const mat& x, const vec& y)
     }
     else
     {
-        for (int i = 0; i < nDp ; i++)
+        for (int i = 0; (uword)i < nDp ; i++)
         {
             vec w = mInitSpatialWeight.weightVector(i);
             mat xtw = trans(x.each_col() % w);
@@ -312,7 +312,7 @@ mat CGwmMGWR::fitAllSerial(const mat& x, const vec& y)
                 mat xtwx_inv = inv_sympd(xtwx);
                 betas.col(i) = xtwx_inv * xtwy;
             }
-            catch (exception e)
+            catch (const exception& e)
             {
                 GWM_LOG_ERROR(e.what());
                 throw e;
@@ -349,7 +349,7 @@ mat CGwmMGWR::fitAllOmp(const mat &x, const vec &y)
                 mS0.row(i) = si;
                 mC.slice(i) = ci;
             }
-            catch (exception e)
+            catch (const exception& e)
             {
                 GWM_LOG_ERROR(e.what());
                 except = e;
@@ -372,7 +372,7 @@ mat CGwmMGWR::fitAllOmp(const mat &x, const vec &y)
                 mat xtwx_inv = inv_sympd(xtwx);
                 betas.col(i) = xtwx_inv * xtwy;
             }
-            catch (exception e)
+            catch (const exception& e)
             {
                 GWM_LOG_ERROR(e.what());
                 except = e;
@@ -412,7 +412,7 @@ vec CGwmMGWR::fitVarSerial(const vec &x, const vec &y, const int var, mat &S)
                 mat si = x(i) * ci;
                 S.row(i) = si;
             }
-            catch (exception e)
+            catch (const exception& e)
             {
                 GWM_LOG_ERROR(e.what());
                 except = e;
@@ -433,7 +433,7 @@ vec CGwmMGWR::fitVarSerial(const vec &x, const vec &y, const int var, mat &S)
                 mat xtwx_inv = inv_sympd(xtwx);
                 betas.col(i) = xtwx_inv * xtwy;
             }
-            catch (exception e)
+            catch (const exception& e)
             {
                 GWM_LOG_ERROR(e.what());
                 except = e;
@@ -474,7 +474,7 @@ vec CGwmMGWR::fitVarOmp(const vec &x, const vec &y, const int var, mat &S)
                 mat si = x(i) * ci;
                 S.row(i) = si;
             }
-            catch (exception e)
+            catch (const exception& e)
             {
                 GWM_LOG_ERROR(e.what());
                 except = e;
@@ -496,7 +496,7 @@ vec CGwmMGWR::fitVarOmp(const vec &x, const vec &y, const int var, mat &S)
                 mat xtwx_inv = inv_sympd(xtwx);
                 betas.col(i) = xtwx_inv * xtwy;
             }
-            catch (exception e)
+            catch (const exception& e)
             {
                 GWM_LOG_ERROR(e.what());
                 except = e;
@@ -532,7 +532,7 @@ double CGwmMGWR::bandwidthSizeCriterionAllCVSerial(CGwmBandwidthWeight *bandwidt
             double res = mY(i) - det(mX.row(i) * beta);
             cv += res * res;
         }
-        catch (exception e)
+        catch (const exception& e)
         {
             GWM_LOG_ERROR(e.what());
             return DBL_MAX;
@@ -567,7 +567,7 @@ double CGwmMGWR::bandwidthSizeCriterionAllCVOmp(CGwmBandwidthWeight *bandwidthWe
                 double res = mY(i) - det(mX.row(i) * beta);
                 cv_all(thread) += res * res;
             }
-            catch (exception e)
+            catch (const exception& e)
             {
                 GWM_LOG_ERROR(e.what());
                 flag = false;
@@ -599,7 +599,7 @@ double CGwmMGWR::bandwidthSizeCriterionAllAICSerial(CGwmBandwidthWeight *bandwid
             shat(0) += si(0, i);
             shat(1) += det(si * si.t());
         }
-        catch (exception e)
+        catch (const exception& e)
         {
             GWM_LOG_ERROR(e.what());
             return DBL_MAX;
@@ -636,7 +636,7 @@ double CGwmMGWR::bandwidthSizeCriterionAllAICOmp(CGwmBandwidthWeight *bandwidthW
                 shat_all(0, thread) += si(0, i);
                 shat_all(1, thread) += det(si * si.t());
             }
-            catch (exception e)
+            catch (const exception& e)
             {
                 GWM_LOG_ERROR(e.what());
                 flag = false;
@@ -674,7 +674,7 @@ double CGwmMGWR::bandwidthSizeCriterionVarCVSerial(CGwmBandwidthWeight *bandwidt
             double res = mYi(i) - det(mXi(i) * beta);
             cv += res * res;
         }
-        catch (exception e)
+        catch (const exception& e)
         {
             GWM_LOG_ERROR(e.what());
             return DBL_MAX;
@@ -710,7 +710,7 @@ double CGwmMGWR::bandwidthSizeCriterionVarCVOmp(CGwmBandwidthWeight *bandwidthWe
                 double res = mYi(i) - det(mXi(i) * beta);
                 cv_all(thread) += res * res;
             }
-            catch (exception e)
+            catch (const exception& e)
             {
                 GWM_LOG_ERROR(e.what());
                 flag = false;
@@ -724,7 +724,7 @@ double CGwmMGWR::bandwidthSizeCriterionVarCVOmp(CGwmBandwidthWeight *bandwidthWe
 double CGwmMGWR::bandwidthSizeCriterionVarAICSerial(CGwmBandwidthWeight *bandwidthWeight)
 {
     int var = mBandwidthSelectionCurrentIndex;
-    uword nDp = mCoords.n_rows, nVar = mX.n_cols;
+    uword nDp = mCoords.n_rows;
     mat betas(1, nDp, fill::zeros);
     vec shat(2, fill::zeros);
     for (uword i = 0; i < nDp ; i++)
@@ -743,7 +743,7 @@ double CGwmMGWR::bandwidthSizeCriterionVarAICSerial(CGwmBandwidthWeight *bandwid
             shat(0) += si(0, i);
             shat(1) += det(si * si.t());
         }
-        catch (exception e)
+        catch (const exception& e)
         {
             GWM_LOG_ERROR(e.what());
             return DBL_MAX;
@@ -757,7 +757,7 @@ double CGwmMGWR::bandwidthSizeCriterionVarAICSerial(CGwmBandwidthWeight *bandwid
 double CGwmMGWR::bandwidthSizeCriterionVarAICOmp(CGwmBandwidthWeight *bandwidthWeight)
 {
     int var = mBandwidthSelectionCurrentIndex;
-    int nDp = mCoords.n_rows, nVar = mX.n_cols;
+    int nDp = mCoords.n_rows;
     mat betas(1, nDp, fill::zeros);
     mat shat_all(2, mOmpThreadNum, fill::zeros);
     bool flag = true;
@@ -781,7 +781,7 @@ double CGwmMGWR::bandwidthSizeCriterionVarAICOmp(CGwmBandwidthWeight *bandwidthW
                 shat_all(0, thread) += si(0, i);
                 shat_all(1, thread) += det(si * si.t());
             }
-            catch (exception e)
+            catch (const exception& e)
             {
                 GWM_LOG_ERROR(e.what());
                 flag = false;

--- a/src/gwmodelpp/CGwmMGWR.cpp
+++ b/src/gwmodelpp/CGwmMGWR.cpp
@@ -389,7 +389,7 @@ mat CGwmMGWR::fitAllOmp(const mat &x, const vec &y)
 }
 #endif
 
-vec CGwmMGWR::fitVarSerial(const vec &x, const vec &y, const size_t var, mat &S)
+vec CGwmMGWR::fitVarSerial(const vec &x, const vec &y, const uword var, mat &S)
 {
     uword nDp = mCoords.n_rows;
     mat betas(1, nDp, fill::zeros);
@@ -450,7 +450,7 @@ vec CGwmMGWR::fitVarSerial(const vec &x, const vec &y, const size_t var, mat &S)
 }
 
 #ifdef ENABLE_OPENMP
-vec CGwmMGWR::fitVarOmp(const vec &x, const vec &y, const size_t var, mat &S)
+vec CGwmMGWR::fitVarOmp(const vec &x, const vec &y, const uword var, mat &S)
 {
     uword nDp = mCoords.n_rows;
     mat betas(1, nDp, fill::zeros);

--- a/src/gwmodelpp/CGwmVariableForwardSelector.cpp
+++ b/src/gwmodelpp/CGwmVariableForwardSelector.cpp
@@ -8,15 +8,15 @@ using namespace std;
 vector<size_t> CGwmVariableForwardSelector::optimize(IGwmVarialbeSelectable *instance)
 {
     vector<size_t> curIndex, restIndex;
-    for (int i = 0; i < mVariables.size(); i++)
+    for (size_t i = 0; i < mVariables.size(); i++)
     {
         restIndex.push_back(i);
     }
     vector<pair<vector<size_t>, double> > modelCriterions;
-    for (int i = 0; i < mVariables.size(); i++)
+    for (size_t i = 0; i < mVariables.size(); i++)
     {
         vec criterions = vec(mVariables.size() - i);
-        for (int j = 0; j < restIndex.size(); j++)
+        for (size_t j = 0; j < restIndex.size(); j++)
         {
             curIndex.push_back(restIndex[j]);
             double aic = instance->getCriterion(convertIndexToVariables(curIndex));

--- a/src/gwmodelpp/CGwmVariableForwardSelector.cpp
+++ b/src/gwmodelpp/CGwmVariableForwardSelector.cpp
@@ -35,7 +35,7 @@ vector<size_t> CGwmVariableForwardSelector::optimize(IGwmVarialbeSelectable *ins
 std::vector<std::size_t> CGwmVariableForwardSelector::convertIndexToVariables(std::vector<std::size_t> index)
 {
     vector<size_t> variables;
-    for (int i : index)
+    for (size_t i : index)
         variables.push_back(mVariables[i]);
     return variables;
 }
@@ -72,7 +72,7 @@ VariablesCriterionList CGwmVariableForwardSelector::indepVarsCriterion() const
     for (pair<vector<size_t>, double> item : mVarsCriterion)
     {
         vector<size_t> variables;
-        for (int i : item.first)
+        for (size_t i : item.first)
         {
             variables.push_back(mVariables[i]);
         }

--- a/src/gwmodelpp/GwmLogger.cpp
+++ b/src/gwmodelpp/GwmLogger.cpp
@@ -4,8 +4,8 @@ using namespace std;
 
 GwmLogger::Logger GwmLogger::logger = [](string message, GwmLogger::LogLevel level, string fun_name, string file_name)
 {
-    (message);
-    (level);
-    (fun_name);
-    (file_name);
+    (void)message;
+    (void)level;
+    (void)fun_name;
+    (void)file_name;
 };

--- a/src/gwmodelpp/GwmLogger.cpp
+++ b/src/gwmodelpp/GwmLogger.cpp
@@ -2,4 +2,10 @@
 
 using namespace std;
 
-GwmLogger::Logger GwmLogger::logger = [](string message, GwmLogger::LogLevel level, string fun_name, string file_name) {};
+GwmLogger::Logger GwmLogger::logger = [](string message, GwmLogger::LogLevel level, string fun_name, string file_name)
+{
+    (message);
+    (level);
+    (fun_name);
+    (file_name);
+};

--- a/src/gwmodelpp/spatialweight/CGwmCRSDistance.cpp
+++ b/src/gwmodelpp/spatialweight/CGwmCRSDistance.cpp
@@ -73,16 +73,6 @@ vec CGwmCRSDistance::SpatialDistance(const rowvec &out_loc, const mat &in_locs)
     return dists;
 }
 
-CGwmCRSDistance::CGwmCRSDistance() : mParameter(nullptr)
-{
-
-}
-
-CGwmCRSDistance::CGwmCRSDistance(bool isGeographic): mParameter(nullptr), mGeographic(isGeographic)
-{
-    mCalculator = mGeographic ? &SpatialDistance : &EuclideanDistance;
-}
-
 CGwmCRSDistance::CGwmCRSDistance(const CGwmCRSDistance &distance) : CGwmDistance(distance)
 {
     mGeographic = distance.mGeographic;

--- a/src/gwmodelpp/spatialweight/CGwmDMatDistance.cpp
+++ b/src/gwmodelpp/spatialweight/CGwmDMatDistance.cpp
@@ -24,7 +24,8 @@ void CGwmDMatDistance::makeParameter(initializer_list<DistParamVariant> plist)
 
 vec CGwmDMatDistance::distance(uword focus)
 {
-    if(mParameter == nullptr) throw std::runtime_error("Parameter is nullptr.");
+    if (mParameter == nullptr) throw std::runtime_error("Parameter is nullptr.");
+    if (focus >= mParameter->total) throw std::runtime_error("Index exceeds ranges.");
     // QFile dmat(mDMatFile);
     // if (focus < mTotal && dmat.open(QFile::QIODevice::ReadOnly))
     // {

--- a/test/BasicGWR.cpp
+++ b/test/BasicGWR.cpp
@@ -74,7 +74,7 @@ TEST_CASE("BasicGWR: adaptive bandwidth autoselection of with CV")
     
     REQUIRE_NOTHROW(algorithm.fit());
 
-    int bw = algorithm.spatialWeight().weight<CGwmBandwidthWeight>()->bandwidth();
+    size_t bw = (size_t)algorithm.spatialWeight().weight<CGwmBandwidthWeight>()->bandwidth();
     REQUIRE(bw == 67);
 }
 


### PR DESCRIPTION
配置编译器选项，使编译器可以显示更多警告。当出于DEBUG模式时，添加选项使编译器以错误的方式报告警告。

添加的选项：

- GCC/Clang：`-Wall -Werror`
- MSVC：`/WX /wd4819 /W4`

修复了警告导致的错误。