### PR TITLE
Fix a bug when MGWR is calibrating without hat matrix

### DIFF
--- a/include/gwmodelpp/CGwmMGWR.h
+++ b/include/gwmodelpp/CGwmMGWR.h
@@ -64,7 +64,7 @@ private:
         return mHasHatMatrix && (mCoords.n_rows < 8192);
     }
 
-    static GwmRegressionDiagnostic CalcDiagnostic(const mat &x, const vec &y, const mat &S0, double RSS);
+    static GwmRegressionDiagnostic CalcDiagnostic(const mat &x, const vec &y, const vec &shat, double RSS);
 
     void setInitSpatialWeight(const CGwmSpatialWeight &spatialWeight)
     {


### PR DESCRIPTION
修复了以下问题

- 当 MGWR 中的 `hasHatmatrix = false` 时，代码中有一个潜在的bug，无法计算 `mS0` 的迹从而无法计算诊断变量。