### PR TITLE
Use custom armadillo_config.h instead of armadillo

### DIFF
--- a/include/armadillo_config.h
+++ b/include/armadillo_config.h
@@ -1,0 +1,10 @@
+#ifndef ARMADILLO_CONFIG
+#define ARMADILLO_CONFIG
+
+#ifdef USE_RCPPARMADILLO
+#include <RcppArmadillo.h>
+#else   // USE_RCPPARMADILLO
+#include <armadillo>
+#endif  // USE_RCPPARMADILLO
+
+#endif  // ARMADILLO_CONFIG

--- a/include/gwmodelcuda/GWRBasicGpuTask.h
+++ b/include/gwmodelcuda/GWRBasicGpuTask.h
@@ -3,7 +3,7 @@
 
 #include <vector>
 #include <memory>
-#include <armadillo>
+#include "armadillo_config.h"
 
 #include "IGWRBasicGpuTask.h"
 #include "../gwmodel.h"

--- a/include/gwmodelpp/GWDR.h
+++ b/include/gwmodelpp/GWDR.h
@@ -2,7 +2,7 @@
 #define GWDR_H
 
 #include <vector>
-#include <armadillo>
+#include "armadillo_config.h"
 #include <gsl/gsl_vector.h>
 #include "SpatialAlgorithm.h"
 #include "spatialweight/SpatialWeight.h"

--- a/include/gwmodelpp/GWPCA.h
+++ b/include/gwmodelpp/GWPCA.h
@@ -1,7 +1,7 @@
 #ifndef GWPCA_H
 #define GWPCA_H
 
-#include <armadillo>
+#include "armadillo_config.h"
 #include <vector>
 #include <tuple>
 #include "SpatialMonoscaleAlgorithm.h"

--- a/include/gwmodelpp/GeneralizedLinearModel.h
+++ b/include/gwmodelpp/GeneralizedLinearModel.h
@@ -1,7 +1,7 @@
 #ifndef GENERALIZEDLINEARMODEL_H
 #define GENERALIZEDLINEARMODEL_H
 
-#include <armadillo>
+#include "armadillo_config.h"
 #include "LinearModel.h"
 #include "GWRGeneralized.h"
 

--- a/include/gwmodelpp/IMultivariableAnalysis.h
+++ b/include/gwmodelpp/IMultivariableAnalysis.h
@@ -1,7 +1,7 @@
 #ifndef IMULTIVARIABLEANALYSIS_H
 #define IMULTIVARIABLEANALYSIS_H
 
-#include <armadillo>
+#include "armadillo_config.h"
 
 namespace gwm
 {

--- a/include/gwmodelpp/IRegressionAnalysis.h
+++ b/include/gwmodelpp/IRegressionAnalysis.h
@@ -2,7 +2,7 @@
 #define IREGRESSIONANALYSIS_H
 
 #include <vector>
-#include <armadillo>
+#include "armadillo_config.h"
 #include "RegressionDiagnostic.h"
 
 

--- a/include/gwmodelpp/LinearModel.h
+++ b/include/gwmodelpp/LinearModel.h
@@ -1,7 +1,7 @@
 #ifndef GWMLINEARMODEL_H
 #define GWMLINEARMODEL_H
 
-#include <armadillo>
+#include "armadillo_config.h"
 
 namespace gwm
 {

--- a/include/gwmodelpp/SpatialAlgorithm.h
+++ b/include/gwmodelpp/SpatialAlgorithm.h
@@ -2,7 +2,7 @@
 #define SPATIALALGORITHM_H
 
 #include "Algorithm.h"
-#include <armadillo>
+#include "armadillo_config.h"
 
 namespace gwm
 {

--- a/include/gwmodelpp/VariableForwardSelector.h
+++ b/include/gwmodelpp/VariableForwardSelector.h
@@ -2,7 +2,7 @@
 #define VARIABLEFORWARDSELECTOR_H
 
 #include <utility>
-#include <armadillo>
+#include "armadillo_config.h"
 #include "IVarialbeSelectable.h"
 
 namespace gwm

--- a/include/gwmodelpp/spatialweight/Distance.h
+++ b/include/gwmodelpp/spatialweight/Distance.h
@@ -9,7 +9,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
-#include <armadillo>
+#include "armadillo_config.h"
 #include <variant>
 
 

--- a/include/gwmodelpp/spatialweight/Weight.h
+++ b/include/gwmodelpp/spatialweight/Weight.h
@@ -8,7 +8,7 @@
 
 #include <unordered_map>
 #include <string>
-#include <armadillo>
+#include "armadillo_config.h"
 
 
 namespace gwm

--- a/include/gwmodelpp/utils/cumat.hpp
+++ b/include/gwmodelpp/utils/cumat.hpp
@@ -2,7 +2,7 @@
 #define CUMAT_HPP
 
 #include <exception>
-#include <armadillo>
+#include "armadillo_config.h"
 #include <cuda_runtime.h>
 #include <cublas_v2.h>
 

--- a/src/gwmodelpp/VariableForwardSelector.cpp
+++ b/src/gwmodelpp/VariableForwardSelector.cpp
@@ -1,6 +1,6 @@
 #include "VariableForwardSelector.h"
 
-#include <armadillo>
+#include "armadillo_config.h"
 
 using namespace arma;
 using namespace std;

--- a/src/gwmodelpp/utils/CudaUtils.cpp
+++ b/src/gwmodelpp/utils/CudaUtils.cpp
@@ -1,6 +1,6 @@
 #include "CudaUtils.h"
 #include <iostream>
-#include <armadillo>
+#include "armadillo_config.h"
 using namespace std;
 using namespace arma;
 

--- a/test/include/londonhp.h
+++ b/test/include/londonhp.h
@@ -1,5 +1,5 @@
 #include <vector>
 #include <string>
-#include <armadillo>
+#include "armadillo_config.h"
 
 bool read_londonhp(arma::mat& coords, arma::mat& data, std::vector<std::string>& fields);

--- a/test/include/londonhp100.h
+++ b/test/include/londonhp100.h
@@ -1,6 +1,6 @@
 #include <vector>
 #include <string>
-#include <armadillo>
+#include "armadillo_config.h"
 
 bool read_londonhp100(arma::mat& coords, arma::mat& data, std::vector<std::string>& fields);
 


### PR DESCRIPTION
A macro `USE_RCPPARMADILLO` can be used to control whether to use RcppArmadillo.h or not.